### PR TITLE
Add a quick note about the XSL Dependency in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+### Dependencies
+
+- php: Requires XSL to be activated
+Information can be found at [the PHP:XSL Manual](http://php.net/manual/en/book.xsl.php)
+
+`````
+To Enable:
+In your php.ini
+1. Uncomment ;extension=php_xsl.dll
+2. Change extension_dir to
+     extension_dir = "./ext"
+`````


### PR DESCRIPTION
Not all machines have XSL on by default. It should be mentioned as a dependency.

Otherwise, saving/uploading a poem causes an error:
`````
Fatal error: Uncaught Error: Class 'XSLTProcessor' not found in 
...\wp-content\plugins\prosody_plugin\prosody.php:52 Stack trace: #0 
...\wp-includes\class-wp-hook.php(300): prosody_xml_transform(Object(WP_Post)) #1 
...\wp-includes\class-wp-hook.php(323): WP_Hook->apply_filters('', Array) #2 
...\wp-includes\plugin.php(453): WP_Hook->do_action(Array) #3 
...\wp-includes\meta.php(267): do_action('updated_post_me...', '9', 10, '_edit_lock', '1500216926:1') #4
...\wp-includes\post.php(1781): update_metadata('post', 10, '_edit_lock', '1500216926:1', '') #5 
...\wp-admin\includes\post.php(1503): update_post_meta(10, '_edit_lock', '1500216926:1') #6 
...\wp-admin\post.php(148): wp_set_post_lock(10) #7 {main} thrown in 
...\wp-content\plugins\prosody_plugin\prosody.php on line 52
`````