### PR TITLE
Check image source against longer uri to avoid false positives

### DIFF
--- a/js/handlers.js
+++ b/js/handlers.js
@@ -214,8 +214,8 @@ function showNote(lineNumber) {
 }
 
 function showSyncopation() {
-  var corrects = $('img[src$="correct.png"]');
-  var expecteds = $('img[src$="expected.png"]');
+  var corrects = $('img[src$="images/correct.png"]');
+  var expecteds = $('img[src$="images/expected.png"]');
   var totalCorrect = corrects.length + expecteds.length;
   var numLines = $('.prosody-line');
   if (totalCorrect === numLines.length * 3){


### PR DESCRIPTION
This is a quick fix for issue #6 

But I agree that a more solid solution would involve checking against something such as the `data-met` attribute. Abstracting the poem as a js object would allow for even more stable state-checks.