### PR TITLE
remove extra 'var' statement after basic linting

### DIFF
--- a/js/handlers.js
+++ b/js/handlers.js
@@ -182,7 +182,7 @@ function checkstress ( lineNumber ) {
     var answer = $('#prosody-real-' + lineNumber).data('real').split('|');
     var realAnswer = answer[0].replace(/-/g, '\u222a');
     // Remove the parentheses that some poems have for optional stress marks
-    var realAnswer = realAnswer.replace(/\(|\)/g, '');
+    realAnswer = realAnswer.replace(/\(|\)/g, '');
     var expectedAnswer;
     // if answer[1] exists, and answer[1] does not equal answer[0]
     if ( answer[1] && answer[1] !== answer[0] ) {


### PR DESCRIPTION
After running a basic lint of handlers.js, this was the only recommended change.