### PR TITLE
Issue11 notebutton

### DIFF
--- a/js/handlers.js
+++ b/js/handlers.js
@@ -10,18 +10,18 @@ var STRESS_WIDTH = 1;
 var lineStates = [];
 
 if (!String.prototype.endsWith) {
-  String.prototype.endsWith = function(searchString, position) {
-      var subjectString = this.toString();
-      if (position === undefined || position > subjectString.length) {
-        position = subjectString.length;
-      }
-      position -= searchString.length;
-      var lastIndex = subjectString.indexOf(searchString, position);
-      return lastIndex !== -1 && lastIndex === position;
-  };
+    String.prototype.endsWith = function(searchString, position) {
+        var subjectString = this.toString();
+        if (position === undefined || position > subjectString.length) {
+            position = subjectString.length;
+        }
+        position -= searchString.length;
+        var lastIndex = subjectString.indexOf(searchString, position);
+        return lastIndex !== -1 && lastIndex === position;
+    };
 }
 
-$(document).ready(function(){
+$(document).ready(function() {
 
     // Set initial stress to an empty string for all real spans
     var realSpans = $('span[real]');
@@ -37,47 +37,47 @@ $(document).ready(function(){
     $('#rhymespacer').height(spacerHeight + 'px');
 
     // Set initial width of shadowsyllables
-    setTimeout(function(){
-      var shadowSyllables = $('.prosody-shadowsyllable');
-      shadowSyllables.each(function (i) {
-          var correspondingRealSyllable = $('#prosody-real-' + shadowSyllables[i].id.substring(15));
-          var correspondingRealSyllableWidth = correspondingRealSyllable.innerWidth();
-          shadowSyllables[i].style.width = correspondingRealSyllableWidth + 'px';
-      });
+    setTimeout(function() {
+        var shadowSyllables = $('.prosody-shadowsyllable');
+        shadowSyllables.each(function(i) {
+            var correspondingRealSyllable = $('#prosody-real-' + shadowSyllables[i].id.substring(15));
+            var correspondingRealSyllableWidth = correspondingRealSyllable.innerWidth();
+            shadowSyllables[i].style.width = correspondingRealSyllableWidth + 'px';
+        });
     }, 500);
 
     // Click handlers for toggles
-    $('#togglestress').click(function(){
+    $('#togglestress').click(function() {
         togglestress(this);
     });
-    $('#togglefeet').click(function(){
+    $('#togglefeet').click(function() {
         togglefeet(this);
     });
-    $('#togglecaesura').click(function(){
+    $('#togglecaesura').click(function() {
         togglecaesura(this);
     });
-    $('#togglediscrepancies').click(function(){
-      toggledifferences(this);
+    $('#togglediscrepancies').click(function() {
+        toggledifferences(this);
     });
 
     // Hide the syncopation checkbox
     $('#syncopation').hide();
 
     // initialize watch events to toggle the rhymebar
-    $('#rhymebar').on('click', function(){
+    $('#rhymebar').on('click', function() {
         $('#rhyme').toggle();
     });
-    $('#rhymeflag').on('click', function(){
+    $('#rhymeflag').on('click', function() {
         $('#rhyme').toggle();
     });
 
     // watch for rhymeform submission and set scheme and answer
-    $('#rhymeform').on('submit', function(event){
+    $('#rhymeform').on('submit', function(event) {
         var scheme = $('#rhymeform').attr('name').replace(/\s/g, "");
         var ans = "";
 
         var total = $('#rhymeform :input[type=text]');
-        $.each( total, function(index, object){
+        $.each(total, function(index, object) {
             ans += object.value;
         });
         checkrhyme(scheme, ans);
@@ -96,30 +96,30 @@ $(document).ready(function(){
 });
 
 var getLineFeatureState = function(lineNumber, feature) {
-    if (lineStates && lineStates[lineNumber-1]) {
-        if (undefined !== lineStates[lineNumber-1][feature]) {
-            return lineStates[lineNumber-1][feature];
+    if (lineStates && lineStates[lineNumber - 1]) {
+        if (undefined !== lineStates[lineNumber - 1][feature]) {
+            return lineStates[lineNumber - 1][feature];
         } else {
             setLineFeatureState(lineNumber, feature, false);
             return false;
         }
     } else {
-        console.error('Cannot read state for Line ' + (lineNumber-1) + '.');
+        console.error('Cannot read state for Line ' + (lineNumber - 1) + '.');
         return false;
     }
 }
 var setLineFeatureState = function(lineNumber, feature, state) {
-    if (lineStates && lineStates[lineNumber-1]) {
-        lineStates[lineNumber-1][feature] = state;
+    if (lineStates && lineStates[lineNumber - 1]) {
+        lineStates[lineNumber - 1][feature] = state;
         if (state === true) { // check if Note needs to be shown
             showNote(lineNumber);
         }
     } else {
-        console.error('Cannot read state for Line ' + (lineNumber-1) + '.');
+        console.error('Cannot read state for Line ' + (lineNumber - 1) + '.');
     }
 }
 
-function checkrhyme (scheme, answer) {
+function checkrhyme(scheme, answer) {
     if (scheme === answer) {
         $('#rhymecheck').addClass('right');
         $('#rhymecheck').removeClass('wrong');
@@ -131,23 +131,23 @@ function checkrhyme (scheme, answer) {
     }
 }
 
-function checkmeter ( lineNumber, lineGroupIndex ) {
+function checkmeter(lineNumber, lineGroupIndex) {
     var fullAnswer = $('#prosody-real-' + lineNumber + " span[answer]").attr('answer');
     if (!fullAnswer) {
-      console.log("There is no answer given for this line.");
+        console.log("There is no answer given for this line.");
     }
     var footType = fullAnswer.split('(')[0];
-    var numberFeet = fullAnswer.match(/\d+/g)[lineGroupIndex-1];
+    var numberFeet = fullAnswer.match(/\d+/g)[lineGroupIndex - 1];
     var correctAnswer = footType + numberFeet;
 
-    $('#check-answer').one("click", function () {
+    $('#check-answer').one("click", function() {
         var feature = 'meter';
         var meterCorrect = getLineFeatureState(lineNumber, feature);
         var footScheme = $('#foot-select').val();
         var numberScheme = $('#number-select').val();
         var fullScheme = footScheme + numberScheme;
 
-        if ( correctAnswer === fullScheme ) {
+        if (correctAnswer === fullScheme) {
             $('#checkmeter' + lineNumber + " img").attr("src", correctAnswerUrl);
             meterCorrect = true;
         } else {
@@ -155,26 +155,26 @@ function checkmeter ( lineNumber, lineGroupIndex ) {
             meterCorrect = false;
         }
 
-        $('#meter-select').dialog( "close" );
+        $('#meter-select').dialog("close");
         showSyncopation();
         setLineFeatureState(lineNumber, feature, meterCorrect);
     });
 
-    $('#meter-select').dialog( "open" );
+    $('#meter-select').dialog("open");
 }
 
-function switchstress (shadowSyllable) {
+function switchstress(shadowSyllable) {
     var realSyllable = $('#prosody-real-' + shadowSyllable.id.substring(15));
     var stress = realSyllable.attr('data-stress');
 
-    if( stress === '-' || stress === '' ) {
+    if (stress === '-' || stress === '') {
         $('#' + shadowSyllable.id).fadeIn();
         $('#' + shadowSyllable.id).empty();
         $('#' + shadowSyllable.id).append(marker(realSyllable));
         realSyllable.attr('data-stress', '+');
-    } else if ( stress === "+") {
+    } else if (stress === "+") {
         $('#' + shadowSyllable.id).fadeOut();
-        setTimeout(function () {
+        setTimeout(function() {
             $('#' + shadowSyllable.id).empty();
             $('#' + shadowSyllable.id).append(slackmarker(realSyllable));
             realSyllable.attr('data-stress', '\u222a');
@@ -182,7 +182,7 @@ function switchstress (shadowSyllable) {
         $('#' + shadowSyllable.id).fadeIn();
     } else {
         $('#' + shadowSyllable.id).fadeOut();
-        setTimeout(function () {
+        setTimeout(function() {
             $('#' + shadowSyllable.id).empty();
             $('#' + shadowSyllable.id).append(placeholder(realSyllable));
             realSyllable.attr('data-stress', '-');
@@ -194,19 +194,19 @@ function switchstress (shadowSyllable) {
     var sub = digits.exec(shadowSyllable.id);
     var shadowLineNumber = '';
     if (sub !== null) {
-      shadowLineNumber = sub[0];
+        shadowLineNumber = sub[0];
     }
 
     $('#checkstress' + shadowLineNumber + ' img').attr('src', siteUrl + '/wp-content/plugins/prosody_plugin/images/stress-default.png');
 }
 
-function checkstress ( lineNumber ) {
+function checkstress(lineNumber) {
     var feature = 'stress';
     var stressCorrect = getLineFeatureState(lineNumber, feature);
     // Scheme is the user submitted stress marks
     var scheme = '';
     $('#prosody-real-' + lineNumber + ' span[real]').each(
-        function () {
+        function() {
             var syllableStress = this.dataset.stress;
             scheme += syllableStress;
         }
@@ -216,7 +216,7 @@ function checkstress ( lineNumber ) {
     var answerLength = $('#prosody-real-' + lineNumber + ' span[real]').length;
     var schemeLength = scheme.length;
 
-    if ( answerLength !== schemeLength ) {
+    if (answerLength !== schemeLength) {
         alert("An answer must be complete to be submitted. Please fill in a symbol over each syllable in this line.");
         setLineFeatureState(lineNumber, feature, false);
         return;
@@ -228,16 +228,16 @@ function checkstress ( lineNumber ) {
     realAnswer = realAnswer.replace(/\(|\)/g, '');
     var expectedAnswer;
     // if answer[1] exists, and answer[1] does not equal answer[0]
-    if ( answer[1] && answer[1] !== answer[0] ) {
+    if (answer[1] && answer[1] !== answer[0]) {
         expectedAnswer = answer[1].replace(/-/g, '\u222a');
     }
 
-    
-    if ( scheme === realAnswer ) {
+
+    if (scheme === realAnswer) {
         $("#checkstress" + lineNumber + " img").attr("src", correctAnswerUrl);
         stressCorrect = true;
         // showNote(lineNumber);
-    } else if ( scheme === expectedAnswer) {
+    } else if (scheme === expectedAnswer) {
         $("#checkstress" + lineNumber + " img").attr("src", expectedAnswerUrl);
         stressCorrect = true;
         // showNote(lineNumber);
@@ -253,13 +253,13 @@ function checkstress ( lineNumber ) {
 
 function verifyShowNote(lineNumber) {
     var criteria = ['stress', 'meter', 'feet'];
-    var verified = criteria.filter((feature) => lineStates[lineNumber-1][feature]); // filter out the features that are not set to "true"
+    var verified = criteria.filter((feature) => lineStates[lineNumber - 1][feature]); // filter out the features that are not set to "true"
     return criteria.length === verified.length;
 }
 
 function showNote(lineNumber) {
     if (verifyShowNote(lineNumber)) {
-        $("#displaynotebutton" + lineNumber).show().click(function(){
+        $("#displaynotebutton" + lineNumber).show().click(function() {
             $('#hintfor' + lineNumber).hide();
             togglenote(lineNumber);
         });
@@ -267,21 +267,21 @@ function showNote(lineNumber) {
 }
 
 function showSyncopation() {
-  var corrects = $('img[src$="images/correct.png"]');
-  var expecteds = $('img[src$="images/expected.png"]');
-  var totalCorrect = corrects.length + expecteds.length;
-  var numLines = $('.prosody-line');
-  if (totalCorrect === numLines.length * 3){
-    $('#syncopation').show();
-  } else if (totalCorrect !== numLines.length){
-    $('#syncopation').hide();
-  }
+    var corrects = $('img[src$="images/correct.png"]');
+    var expecteds = $('img[src$="images/expected.png"]');
+    var totalCorrect = corrects.length + expecteds.length;
+    var numLines = $('.prosody-line');
+    if (totalCorrect === numLines.length * 3) {
+        $('#syncopation').show();
+    } else if (totalCorrect !== numLines.length) {
+        $('#syncopation').hide();
+    }
 }
 
-function switchfoot ( syllableId ) {
+function switchfoot(syllableId) {
 
-  var syllableSpan = $('#' + syllableId + ' span');
-    if ( syllableSpan.length === 0 ) {
+    var syllableSpan = $('#' + syllableId + ' span');
+    if (syllableSpan.length === 0) {
         $('#' + syllableId).append('<span class="prosody-footmarker">|</span>');
         syllableSpan = $('#' + syllableId + ' span');
     } else {
@@ -292,7 +292,7 @@ function switchfoot ( syllableId ) {
     var digit_group = digit_search.exec(syllableId);
     var shadowLineNumberSection = '';
     if (digit_group !== null) {
-      shadowLineNumberSection = digit_group[0];
+        shadowLineNumberSection = digit_group[0];
     }
 
     $("#checkfeet" + shadowLineNumberSection + " img").attr("src", siteUrl + "/wp-content/plugins/prosody_plugin/images/feet-default.png");
@@ -301,25 +301,25 @@ function switchfoot ( syllableId ) {
     var footSyllableWidth = footSyllable.width();
     var footSyllableId = footSyllable.attr('id').substring(13);
     var footShadowSyllable = $('#prosody-shadow-' + footSyllableId);
-    setTimeout(function(){
-      footShadowSyllable.width(footSyllableWidth - STRESS_WIDTH);
+    setTimeout(function() {
+        footShadowSyllable.width(footSyllableWidth - STRESS_WIDTH);
     }, 100);
 }
 
-function checkfeet ( lineNumber ) {
+function checkfeet(lineNumber) {
     var feature = 'feet';
     var feetCorrect = getLineFeatureState(lineNumber, feature);
     var scheme = $('#prosody-real-' + lineNumber + ' span[real]').text();
     var answer = $('#prosody-real-' + lineNumber).data('feet');
-    if ( scheme.endsWith('|')) {
+    if (scheme.endsWith('|')) {
         scheme = scheme.slice(0, -1);
     }
 
-   // remove everything but words, numbers and pipe
+    // remove everything but words, numbers and pipe
     answer = answer.replace(/[^\w|]/g, '');
     scheme = scheme.replace(/[^\w|]/g, '');
 
-    if ( scheme === answer) {
+    if (scheme === answer) {
         $("#checkfeet" + lineNumber + " img").attr("src", correctAnswerUrl);
         feetCorrect = true;
     } else {
@@ -332,55 +332,55 @@ function checkfeet ( lineNumber ) {
 }
 
 function togglenote(lineNumber) {
-  if($('#hintfor' + lineNumber).css('display') == 'none'){
-    $('#hintfor' + lineNumber).dialog();
-    $('#hintfor' + lineNumber).show();
-  } else {
-    $('#hintfor' + lineNumber).dialog('close');
-    $('#hintfor' + lineNumber).hide();
-  }
-}
-
-function togglestress ( node ) {
-    $('.prosody-marker').each(function(i, el){
-        if(node.checked){
-            $(el).show();
-        } else {
-            $(el).hide();
-        }
-    });
-
-}
-
-function togglefeet (node) {
-    $('.prosody-footmarker').each(function(i, el){
-        if(node.checked){
-            $(el).show();
-        } else {
-            $(el).hide();
-        }
-    });
-}
-
-function togglecaesura (node) {
-    $('.caesura').each(function(i, el){
-        if(node.checked){
-            $(el).show();
-        } else {
-            $(el).hide();
-        }
-    });
-}
-
-function toggledifferences (node) {
-    if (node.checked){
-      $('span[discrepant]').addClass('discrep');
+    if ($('#hintfor' + lineNumber).css('display') == 'none') {
+        $('#hintfor' + lineNumber).dialog();
+        $('#hintfor' + lineNumber).show();
     } else {
-      $('span[discrepant]').removeClass('discrep');
+        $('#hintfor' + lineNumber).dialog('close');
+        $('#hintfor' + lineNumber).hide();
     }
 }
 
-function addMarker ( real, symbol ) {
+function togglestress(node) {
+    $('.prosody-marker').each(function(i, el) {
+        if (node.checked) {
+            $(el).show();
+        } else {
+            $(el).hide();
+        }
+    });
+
+}
+
+function togglefeet(node) {
+    $('.prosody-footmarker').each(function(i, el) {
+        if (node.checked) {
+            $(el).show();
+        } else {
+            $(el).hide();
+        }
+    });
+}
+
+function togglecaesura(node) {
+    $('.caesura').each(function(i, el) {
+        if (node.checked) {
+            $(el).show();
+        } else {
+            $(el).hide();
+        }
+    });
+}
+
+function toggledifferences(node) {
+    if (node.checked) {
+        $('span[discrepant]').addClass('discrep');
+    } else {
+        $('span[discrepant]').removeClass('discrep');
+    }
+}
+
+function addMarker(real, symbol) {
     var prosodyMarker = document.createElement("span");
     prosodyMarker.className = "prosody-marker";
 
@@ -388,20 +388,20 @@ function addMarker ( real, symbol ) {
     return prosodyMarker;
 }
 
-function marker ( real ) {
-    return addMarker( real, "/" ) ;
+function marker(real) {
+    return addMarker(real, "/");
 }
 
-function slackmarker ( real ) {
-    return addMarker ( real, "\u222A" );
+function slackmarker(real) {
+    return addMarker(real, "\u222A");
 }
 
-function placeholder ( real ) {
-    return addMarker( real, " " );
+function placeholder(real) {
+    return addMarker(real, " ");
 }
 
-function decodeEntities (encodedString) {
-  var textArea = document.createElement('textarea');
-  textArea.innerHTML = encodedString;
-  return textArea.value;
+function decodeEntities(encodedString) {
+    var textArea = document.createElement('textarea');
+    textArea.innerHTML = encodedString;
+    return textArea.value;
 }


### PR DESCRIPTION
I abstracted out the way that the "correctness state" of different line features is tracked. Then I added a `verifyShowNote` function to check all three features whenever a correct feature submission is made for stress, meter, or feet.

Now the note shows up only when all three have been completed correctly for a given line, regardless of the order in which they are completed.

Because this was a different branch from the others, it does not include the linting from pull request #10 , but it does resolve issue #11 -- I recommend merging #9 and #10 first, then I can correct any conflicts, should they show up.